### PR TITLE
Add OpenStrap Edge to Wearables

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,8 +998,8 @@ All the projects added in this project are featured in [fluttergems.dev](https:/
 
 | Project | Repo | Description |
 |:--------|:-----|:------------|
-| Live Scores App | [Link](https://github.com/jepbura/Live-Scores-App-V3Live) | See live football and volleyball scores on your smartwatch. |
-| BFRBSys | [Link](https://github.com/xtnctx/bfrbsys) | A wrist-worn device and monitoring system for a person with Body-focused Repetitive Behavior. |
+| BFRBSys | [Link](https://github.com/xtnctx/bfrbsys) | A wrist-worn device and monitoring system for a person with Body-focused Repetitive Behavior |
+| Live Scores App | [Link](https://github.com/jepbura/Live-Scores-App-V3Live) | See live football and volleyball scores on your smartwatch |
 | OpenStrap Edge | [Link](https://github.com/OpenStrap/edge) | Reverse-engineered WHOOP 4.0 companion app — Bluetooth sync and all HRV/sleep/strain analytics computed on-device, no cloud or subscription required |
 | Reader for WearOS (Bible incl) | [Link](https://github.com/KyleFin/wear-bible-ereader) | Read epub books on your smartwatch. |
 

--- a/README.md
+++ b/README.md
@@ -1000,8 +1000,8 @@ All the projects added in this project are featured in [fluttergems.dev](https:/
 |:--------|:-----|:------------|
 | Live Scores App | [Link](https://github.com/jepbura/Live-Scores-App-V3Live) | See live football and volleyball scores on your smartwatch. |
 | BFRBSys | [Link](https://github.com/xtnctx/bfrbsys) | A wrist-worn device and monitoring system for a person with Body-focused Repetitive Behavior. |
+| OpenStrap Edge | [Link](https://github.com/OpenStrap/edge) | Reverse-engineered WHOOP 4.0 companion app — Bluetooth sync and all HRV/sleep/strain analytics computed on-device, no cloud or subscription required |
 | Reader for WearOS (Bible incl) | [Link](https://github.com/KyleFin/wear-bible-ereader) | Read epub books on your smartwatch. |
-| OpenStrap Edge | [Link](https://github.com/OpenStrap/edge) | Reverse-engineered WHOOP 4.0 companion app — Bluetooth sync and all HRV/sleep/strain analytics computed on-device, no cloud or subscription required. |
 
 
 ### Admin Dashboard

--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,7 @@ All the projects added in this project are featured in [fluttergems.dev](https:/
 | Live Scores App | [Link](https://github.com/jepbura/Live-Scores-App-V3Live) | See live football and volleyball scores on your smartwatch. |
 | BFRBSys | [Link](https://github.com/xtnctx/bfrbsys) | A wrist-worn device and monitoring system for a person with Body-focused Repetitive Behavior. |
 | Reader for WearOS (Bible incl) | [Link](https://github.com/KyleFin/wear-bible-ereader) | Read epub books on your smartwatch. |
+| OpenStrap Edge | [Link](https://github.com/OpenStrap/edge) | Reverse-engineered WHOOP 4.0 companion app — Bluetooth sync and all HRV/sleep/strain analytics computed on-device, no cloud or subscription required. |
 
 
 ### Admin Dashboard


### PR DESCRIPTION
Closes #774

Adds OpenStrap Edge to the Wearables section — an open-source Flutter app that reverse-engineers the WHOOP 4.0's Bluetooth protocol and computes HRV/sleep/strain analytics entirely on-device (no cloud, no subscription). Actively maintained.