### PR TITLE
Add Mise to Wallets, Payments & PoS and Helm to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ All the projects added in this project are featured in [fluttergems.dev](https:/
 | Invoice Ninja            | [Link](https://github.com/invoiceninja/admin-portal)             | Invoice Ninja: Desktop/mobile admin portal |
 | Invoice Pdf | [Link](https://github.com/sabikrahat/invoice_pdf_generate) | App to generate invoices in PDF format |
 | MiGo POS Software | [Link](https://github.com/poslevel/migo) | A POS Software that works everywhere seamlessly |
+| Mise | [Link](https://github.com/devShakib015/mise) | A complete restaurant system that runs on one Mac — till, kitchen display, QR table ordering and back office. Self-hosted and fully offline. |
 | MPoS | [Link](https://github.com/kiks12/mpos-flutter) | Mobile Point of Sale System for Four Angels Retail Shop |
 | okane | [Link](https://gitlab.com/wolfenrain/okane) | okane is an unnecessarily complicated and over-engineered invoice generator. |
 | Peercoin | [Link](https://github.com/peercoin/peercoin_flutter) | Light Peercoin wallet written in Flutter, deployable on Android, iOS and Web. |
@@ -321,6 +322,7 @@ All the projects added in this project are featured in [fluttergems.dev](https:/
 | Floating Volume | [Link](https://github.com/mkalmousli/floatingvolume) | Control your device’s volume with a floating slider on Android. |
 | Frigoligo | [Link](https://github.com/casimir/frigoligo) | A wallabag client to take your links anywhere and keep them fresh! |
 | Gopeed | [Link](https://github.com/GopeedLab/gopeed) | A modern download manager that supports all platforms |
+| Helm | [Link](https://github.com/devShakib015/helm) | A macOS toolkit putting fifteen native tools in one window: storage cleaner with a treemap explorer, duplicate finder, system monitors with 24h history, clipboard manager and app uninstaller. |
 | Holidayz | [Link](https://github.com/paskozhelev/holidayz-app) | Stay Ahead with Global Public Holidays & Regional Days Off |
 | IdiomReplaceX Browser | [Link](https://github.com/idiomreplacex/idiomreplacex-app) | The IdiomReplaceX Browser App is a special browser app where IdiomReplaceX toolbox is added to almost any web page, allowing literary filters to be applied to the content of the web page |
 | Keyviz | [Link](https://github.com/softwarearchitect817/keyviz) | Let your audience know what handy shortcuts/keys you're pressing during screencasts, presentations, collaborations, or whenever you need it. |

--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ All the projects added in this project are featured in [fluttergems.dev](https:/
 | Invoice Ninja            | [Link](https://github.com/invoiceninja/admin-portal)             | Invoice Ninja: Desktop/mobile admin portal |
 | Invoice Pdf | [Link](https://github.com/sabikrahat/invoice_pdf_generate) | App to generate invoices in PDF format |
 | MiGo POS Software | [Link](https://github.com/poslevel/migo) | A POS Software that works everywhere seamlessly |
-| Mise | [Link](https://github.com/devShakib015/mise) | A complete restaurant system that runs on one Mac — till, kitchen display, QR table ordering and back office. Self-hosted and fully offline. |
 | MPoS | [Link](https://github.com/kiks12/mpos-flutter) | Mobile Point of Sale System for Four Angels Retail Shop |
 | okane | [Link](https://gitlab.com/wolfenrain/okane) | okane is an unnecessarily complicated and over-engineered invoice generator. |
 | Peercoin | [Link](https://github.com/peercoin/peercoin_flutter) | Light Peercoin wallet written in Flutter, deployable on Android, iOS and Web. |


### PR DESCRIPTION
Closes #785
Closes #786

Adding two open source macOS apps, both MIT licensed and actively maintained (last pushed August 2026).

**Mise** → *Wallets, Payments & PoS*
https://github.com/devShakib015/mise — a complete restaurant system on one Mac: a till for the floor, a kitchen display for the pass, QR table ordering for guests, and a back office for the menu and the numbers. Self-hosted and fully offline, so service continues when the internet does not. Flutter + PocketBase.

**Helm** → *Tools & Utilities*
https://github.com/devShakib015/helm — fifteen native macOS tools in one window: a storage cleaner with a treemap explorer, a duplicate finder, system monitors with 24-hour history, a clipboard manager and an app uninstaller.

Both rows are inserted in alphabetical position within their existing category tables — Mise between MiGo POS Software and MPoS, Helm between Gopeed and Holidayz. No other lines touched.

I raised them as one PR since it is two rows in one file; happy to split into two if you'd prefer.